### PR TITLE
Add flipper to disable old shipper

### DIFF
--- a/lib/searchkick/indexer.rb
+++ b/lib/searchkick/indexer.rb
@@ -16,13 +16,14 @@ module Searchkick
       reset_queue!
       return if items.none?
 
-      response = Searchkick.client.bulk(body: items)
+      disable_shipping_es2 = Flipper.new(Flipper::Adapters::ActiveRecord.new).enabled?(:flipper_fms_disable_shipping_es2)
+      enable_shipping_es7 = Flipper.new(Flipper::Adapters::ActiveRecord.new).enabled?(:flipper_fms_enable_shipping_es7)
 
-      if Flipper.new(Flipper::Adapters::ActiveRecord.new).enabled?(:flipper_fms_enable_shipping_es7)
-        Er::Client.new.bulk_index(items)
-      end
+      response = Searchkick.client.bulk(body: items) if !disable_shipping_es2
 
-      raise_bulk_indexing_exception!(response) if response['errors']
+      Er::Client.new.bulk_index(items) if enable_shipping_es7
+
+      raise_bulk_indexing_exception!(response) if (response['errors'] && !disable_shipping_es2)
     end
 
     private

--- a/lib/searchkick/indexer.rb
+++ b/lib/searchkick/indexer.rb
@@ -23,7 +23,7 @@ module Searchkick
 
       Er::Client.new.bulk_index(items) if enable_shipping_es7
 
-      raise_bulk_indexing_exception!(response) if (response['errors'] && !disable_shipping_es2)
+      raise_bulk_indexing_exception!(response) if (!disable_shipping_es2 && response['errors'])
     end
 
     private


### PR DESCRIPTION
Once the migration is complete we need the ability to disable the old shipping method.